### PR TITLE
2017-04-05-dopplers2017-werbung.md

### DIFF
--- a/_posts/2017/2017-04-05-dopplers2017-werbung.md
+++ b/_posts/2017/2017-04-05-dopplers2017-werbung.md
@@ -1,0 +1,18 @@
+---
+layout: post
+title: DOPPLERS 2017
+categories: special veranstaltungen
+image: 
+author: Vanessa
+---
+
+Vom 07. bis zum 09. April 2017 findet die *Deutsche Olympiade im Physik-Probleme-Lösen Eifrig Rätselnder Studierender* 
+an der TU Dortmund organisiert von der Regionalgruppe Dortmund der jDPG statt. 
+
+Neben dem offiziellen Wettbewerb gibt es am ersten Tag spannende Vorträge, die von allen Studierenden besucht werden 
+können. Professor Dr. Joachim Stolze wird etwas über *Quantencomputing* erzählen, Prof. Dr. Kai Schmidt wird über 
+*Die Suche nach neuen Welten* reden und Prof. Dr. Johannes Haller wird *Neues vom Large Hadron Collider* vorstellen. 
+
+Die Veranstaltung beginnt mit einer Begrüßung am 07.04.2017 um 15:00 in HS7.
+
+Weiter Informationen: [DOPPLERS Programm](https://www.dpg-physik.de/dpg/gliederung/junge/veranstaltungen/dopplers/programm.html)


### PR DESCRIPTION
Werbung für DOPPLERS 2017, organisiert von der jDPG.