### PR TITLE
Links hinzugefügt

### DIFF
--- a/ueber_uns/gremien.html
+++ b/ueber_uns/gremien.html
@@ -9,17 +9,23 @@ category: vorstand
     <h3 class="card-title">Geschäftsführender Vorstand</h3>
     <div class="row">
       <div class="col-4">
-        <img class="card-img portrait" alt="" src="images/vorstand/marie.jpg">
+        <a href="mailto:vorstand@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/marie.jpg">
+        </a>
         <h4>Marie Schmitz</h4>
         <p>1. Vorsitzende</p>
       </div>
       <div class="col-4">
-        <img class="card-img portrait" alt="" src="images/vorstand/kevin.jpg">
+        <a href="mailto:vorstand@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/kevin.jpg">
+        </a>
         <h4>Kevin Heinicke</h4>
         <p>2. Vorsitzender</p>
       </div>
       <div class="col-4 col-md-4">
-        <img class="card-img portrait" alt="" src="images/vorstand/lena.jpg">
+        <a href="mailto:vorstand@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/lena.jpg">
+        </a>
         <h4>Lena Linhoff</h4>
         <p>Finanzreferentin</p>
       </div>
@@ -29,18 +35,24 @@ category: vorstand
 
 <div class="card mb-3">
   <div class="card-body text-center">
-    <h3 class="card-title">Geschäftsführung, Mitgliederverwaltung und Ressourcenverwaltung</h3>
+    <h3 class="card-title">Koordination, Mitgliederverwaltung und Ressourcenverwaltung</h3>
     <div class="row">
       <div class="col-4 col-md-4">
-        <img class="card-img portrait" alt="" src="images/vorstand/max.jpg">
+        <a href="mailto:koordination@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/max.jpg">
+        </a>
         <h4>Maximilian Nöthe</h4>
       </div>
       <div class="col-4 col-md-4">
-        <img class="card-img portrait" alt="" src="images/vorstand/steven.jpg">
+        <a href="mailto:mitgliederverwaltung@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/steven.jpg">
+        </a>
         <h4>Steven Becker</h4>
       </div>
       <div class="col-4 col-md-4">
-        <img class="card-img portrait" alt="" src="images/vorstand/kevinS.jpg">
+        <a href="mailto:ressourcenverwaltung@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/kevinS.jpg">
+        </a>
         <h4>Kevin Schmidt</h4>
       </div>
     </div>
@@ -52,11 +64,15 @@ category: vorstand
     <h3 class="card-title">Begabtenförderung</h3>
     <div class="row">
       <div class="col-4 mx-auto">
-        <img class="card-img portrait" alt="" src="images/passbilddummy.jpg">
+        <a href="mailto:begabtenfoerderung@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/passbilddummy.jpg">
+        </a>
         <h4>Julian Wishahi</h4>
       </div>
       <div class="col-4 mx-auto">
-        <img class="card-img portrait" alt="" src="images/vorstand/thorben.jpg">
+        <a href="mailto:begabtenfoerderung@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/thorben.jpg">
+        </a>
         <h4>Thorben Menne</h4>
       </div>
     </div>
@@ -68,11 +84,15 @@ category: vorstand
     <h3 class="card-title">Fortbildungsprojekte</h3>
     <div class="row">
       <div class="col-4 mx-auto">
-        <img class="card-img portrait" alt="" src="images/vorstand/simone.jpg">
+        <a href="mailto:workshop@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/simone.jpg">
+        </a>
         <h4>Simone Mender</h4>
       </div>
       <div class="col-4 mx-auto">
-        <img class="card-img portrait" alt="" src="images/vorstand/joshua.jpg">
+        <a href="mailto:toolbox@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/joshua.jpg">
+        </a>
         <h4>Joshua Luckey</h4>
       </div>
     </div>
@@ -84,11 +104,15 @@ category: vorstand
     <h3 class="card-title">Öffentlichkeitsarbeit</h3>
     <div class="row">
       <div class="col-4 mx-auto">
-        <img class="card-img portrait" alt="" src="images/vorstand/christophe.jpg">
+        <a href="mailto:oeffentlichkeitsarbeit@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/christophe.jpg">
+        </a>
         <h4>Christophe Cauet</h4>
       </div>
       <div class="col-4 mx-auto">
-        <img class="card-img portrait" alt="" src="images/vorstand/vanessa.jpg">
+        <a href="mailto:oeffentlichkeitsarbeit@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/vanessa.jpg">
+        </a>
         <h4>Vanessa Müller</h4>
       </div>
     </div>
@@ -100,15 +124,21 @@ category: vorstand
     <h3 class="card-title">Alumniarbeit</h3>
     <div class="row">
       <div class="col-4 mx-auto">
-        <img class="card-img portrait" alt="" src="images/vorstand/alex.jpg">
+        <a href="mailto:alumniarbeit@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/alex.jpg">
+        </a>
         <h4>Alex Birnkraut</h4>
       </div>
       <div class="col-4 mx-auto">
-        <img class="card-img portrait" alt="" src="images/vorstand/janine.jpg">
+        <a href="mailto:alumniarbeit@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/janine.jpg">
+        </a>
         <h4>Janine Menne</h4>
       </div>
       <div class="col-4 mx-auto">
-        <img class="card-img portrait" alt="" src="images/vorstand/antje.jpg">
+        <a href="mailto:alumniarbeit@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/antje.jpg">
+        </a>
         <h4>Antje Mödden</h4>
       </div>
     </div>
@@ -117,10 +147,12 @@ category: vorstand
 
 <div class="card mb-3">
   <div class="card-body text-center">
-    <h3 class="card-title">Organisation der Sommerakademie</h3>
+    <h3 class="card-title">Sommerakademie</h3>
     <div class="row">
       <div class="col-4 mx-auto">
-        <img class="card-img portrait" alt="" src="images/vorstand/karl.jpg">
+        <a href="mailto:sommerakademie@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/karl.jpg">
+        </a>
         <h4>Karl Schiller</h4>
       </div>
     </div>
@@ -132,11 +164,15 @@ category: vorstand
     <h3 class="card-title">Wirtschaft</h3>
     <div class="row">
       <div class="col-4 mx-auto">
-        <img class="card-img portrait" alt="" src="images/vorstand/henning.jpg">
+        <a href="mailto:wirtschaft@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/henning.jpg">
+        </a>
         <h4>Henning Moldenhauer</h4>
       </div>
       <div class="col-4 mx-auto">
-        <img class="card-img portrait" alt="" src="images/vorstand/jacqueline.jpg">
+        <a href="mailto:wirtschaft@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/jacqueline.jpg">
+        </a>
         <h4>Jacqueline Schlingmann</h4>
       </div>
     </div>
@@ -148,7 +184,9 @@ category: vorstand
     <h3 class="card-title">Lehramt</h3>
     <div class="row">
       <div class="col-4 mx-auto">
-        <img class="card-img portrait" alt="" src="images/vorstand/thomas.jpg">
+        <a href="mailto:klassenzimmer@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/thomas.jpg">
+        </a>
         <h4>Thomas Honermann</h4>
       </div>
     </div>
@@ -160,7 +198,9 @@ category: vorstand
     <h3 class="card-title">Datenschutz</h3>
     <div class="row">
       <div class="col-4 mx-auto">
-        <img class="card-img portrait" alt="" src="images/vorstand/timon.jpg">
+        <a href="mailto:datenschutz@pep-dortmund.org">
+          <img class="card-img portrait" alt="" src="images/vorstand/timon.jpg">
+        </a>
         <h4>Timon Schmelzer</h4>
       </div>
     </div>


### PR DESCRIPTION
Vorstandsmitglieder sollten ansprechbar sein. Daher wurde auf der Klausurtagung besprochen entsprechende Mailadressen einzurichten und auf der Gremienseite zu verlinken.
Das geschieht nun über die Bilder