### PR TITLE
Only hyphenate in text paragraphs

### DIFF
--- a/assets/css/bootstrap-custom.scss
+++ b/assets/css/bootstrap-custom.scss
@@ -70,6 +70,9 @@ body {
   flex-direction: column;
   font-weight: 300;
   color: #777;
+}
+
+p {
   text-align: justify;
   text-justify: inter-word;
   hyphens: auto;


### PR DESCRIPTION
Wir hatten Blocksatz und Silbentrennung im ganzen body.
Sieht aber eigentlich in allem außer Fließtextparagraphen schlechter aus als Flattersatz.