### PR TITLE
Using / for division outside of calc() is deprecated and will be remo…

### DIFF
--- a/_sass/_functions.scss
+++ b/_sass/_functions.scss
@@ -54,7 +54,7 @@
   $g: green($color);
   $b: blue($color);
 
-  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+  $yiq: calc((($r * 299) + ($g * 587) + ($b * 114)) / 1000);
 
   @if ($yiq >= $yiq-contrasted-threshold) {
     @return $yiq-text-dark;

--- a/_sass/_images.scss
+++ b/_sass/_images.scss
@@ -32,7 +32,7 @@
 }
 
 .figure-img {
-  margin-bottom: ($spacer / 2);
+  margin-bottom: calc($spacer / 2);
   line-height: 1;
 }
 

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -249,7 +249,7 @@ $h4-font-size:                $font-size-base * 1.5 !default;
 $h5-font-size:                $font-size-base * 1.25 !default;
 $h6-font-size:                $font-size-base !default;
 
-$headings-margin-bottom:      ($spacer / 2) !default;
+$headings-margin-bottom:      calc($spacer / 2) !default;
 $headings-font-family:        inherit !default;
 $headings-font-weight:        500 !default;
 $headings-line-height:        1.2 !default;
@@ -587,7 +587,7 @@ $nav-pills-link-active-bg:          $component-active-bg !default;
 
 // Navbar
 
-$navbar-padding-y:                  ($spacer / 2) !default;
+$navbar-padding-y:                  calc($spacer / 2) !default;
 $navbar-padding-x:                  $spacer !default;
 
 $navbar-nav-link-padding-x:         .5rem !default;
@@ -596,7 +596,7 @@ $navbar-brand-font-size:            $font-size-lg !default;
 // Compute the navbar-brand padding-y so the navbar-brand will have the same height as navbar-text and nav-link
 $nav-link-height:                   ($font-size-base * $line-height-base + $nav-link-padding-y * 2) !default;
 $navbar-brand-height:               $navbar-brand-font-size * $line-height-base !default;
-$navbar-brand-padding-y:            ($nav-link-height - $navbar-brand-height) / 2 !default;
+$navbar-brand-padding-y:            calc(($nav-link-height - $navbar-brand-height) / 2) !default;
 
 $navbar-toggler-padding-y:          .25rem !default;
 $navbar-toggler-padding-x:          .75rem !default;
@@ -666,7 +666,7 @@ $card-bg:                           $white !default;
 
 $card-img-overlay-padding:          1.25rem !default;
 
-$card-group-margin:                 ($grid-gutter-width / 2) !default;
+$card-group-margin:                 calc($grid-gutter-width / 2) !default;
 $card-deck-margin:                  $card-group-margin !default;
 
 $card-columns-count:                3 !default;

--- a/_sass/mixins/_grid-framework.scss
+++ b/_sass/mixins/_grid-framework.scss
@@ -9,8 +9,8 @@
     position: relative;
     width: 100%;
     min-height: 1px; // Prevent columns from collapsing when empty
-    padding-right: ($gutter / 2);
-    padding-left: ($gutter / 2);
+    padding-right: calc($gutter / 2);
+    padding-left: calc($gutter / 2);
   }
 
   @each $breakpoint in map-keys($breakpoints) {

--- a/_sass/mixins/_grid.scss
+++ b/_sass/mixins/_grid.scss
@@ -4,8 +4,8 @@
 
 @mixin make-container() {
   width: 100%;
-  padding-right: ($grid-gutter-width / 2);
-  padding-left: ($grid-gutter-width / 2);
+  padding-right: calc($grid-gutter-width / 2);
+  padding-left: calc($grid-gutter-width / 2);
   margin-right: auto;
   margin-left: auto;
 }
@@ -23,8 +23,8 @@
 @mixin make-row() {
   display: flex;
   flex-wrap: wrap;
-  margin-right: ($grid-gutter-width / -2);
-  margin-left: ($grid-gutter-width / -2);
+  margin-right: calc($grid-gutter-width / -2);
+  margin-left: calc($grid-gutter-width / -2);
 }
 
 @mixin make-col-ready() {
@@ -34,19 +34,19 @@
   // later on to override this initial width.
   width: 100%;
   min-height: 1px; // Prevent collapsing
-  padding-right: ($grid-gutter-width / 2);
-  padding-left: ($grid-gutter-width / 2);
+  padding-right: calc($grid-gutter-width / 2);
+  padding-left: calc($grid-gutter-width / 2);
 }
 
 @mixin make-col($size, $columns: $grid-columns) {
-  flex: 0 0 percentage($size / $columns);
+  flex: 0 0 percentage(calc($size / $columns));
   // Add a `max-width` to ensure content within each column does not blow out
   // the width of the column. Applies to IE10+ and Firefox. Chrome and Safari
   // do not appear to require this.
-  max-width: percentage($size / $columns);
+  max-width: percentage(calc($size / $columns));
 }
 
 @mixin make-col-offset($size, $columns: $grid-columns) {
-  $num: $size / $columns;
+  $num: calc($size / $columns);
   margin-left: if($num == 0, 0, percentage($num));
 }

--- a/_sass/mixins/_nav-divider.scss
+++ b/_sass/mixins/_nav-divider.scss
@@ -4,7 +4,7 @@
 
 @mixin nav-divider($color: #e5e5e5) {
   height: 0;
-  margin: ($spacer / 2) 0;
+  margin: calc($spacer / 2) 0;
   overflow: hidden;
   border-top: 1px solid $color;
 }

--- a/_sass/utilities/_embed.scss
+++ b/_sass/utilities/_embed.scss
@@ -29,24 +29,24 @@
 
 .embed-responsive-21by9 {
   &::before {
-    padding-top: percentage(9 / 21);
+    padding-top: percentage(calc(9 / 21));
   }
 }
 
 .embed-responsive-16by9 {
   &::before {
-    padding-top: percentage(9 / 16);
+    padding-top: percentage(calc(9 / 16));
   }
 }
 
 .embed-responsive-4by3 {
   &::before {
-    padding-top: percentage(3 / 4);
+    padding-top: percentage(calc(3 / 4));
   }
 }
 
 .embed-responsive-1by1 {
   &::before {
-    padding-top: percentage(1 / 1);
+    padding-top: percentage(calc(1 / 1));
   }
 }


### PR DESCRIPTION
…ved in Dart Sass 2.0.0.

- Problems with 'calc' in calculations with variables
- happens in '_sass/_card.scss' & '_sass/_custom-forms.scss'

### Checklist

- [ ] All included images are public domain images or their respective licenses are respected (e.g. attribution for CC-BY)
- [ ] Images are reduced to around 2000px at the long edge and in jpg format 
