### PR TITLE
Show free places

### DIFF
--- a/_posts/2022/2022-12-12-bewerbungs_workshop.md
+++ b/_posts/2022/2022-12-12-bewerbungs_workshop.md
@@ -5,7 +5,7 @@ categories: special veranstaltungen
 image: /images/we_need_you_long.png
 author: Yanick, Johannes, Ludwig
 ---
-[Jetzt anmelden!](https://registration.pep-dortmund.org/events/15/registration/)
+[<span class="FreePlaces" event=15>Noch free_places!</span> Jetzt anmelden](https://registration.pep-dortmund.org/events/15/registration/)
 
 Im Januar findet ein weiteres Mal der PeP Bewerbungsworkshop statt: Dabei geht es wieder um das Thema Bewerbungstraining und Finanzverhandlung. 
 Du fragst dich wie es nach dem Studium weiter geht? Du hast vielleicht schon die ein oder andere Idee wo es hingehen soll aber es trennt dich noch der unangenehme Schritt des Bewerbens vom neuen Arbeitgeber? Und dann die Frage nach dem Gehalt…
@@ -14,3 +14,5 @@ Wir bieten dir ein Wochenende lang ein Training an, bei dem du lernst, worauf es
 Der Workshop findet am Wochenende vom 13. bis zum 15. Jaunar in Essen statt und kostet pro Person 15€ inclusive Verpflegung und Unterkunft. Anmelden kannst du dich [hier](https://registration.pep-dortmund.org/events/15/registration/).
 
 Bei Fragen melde dich gerne per [Mail](mailto:workshop@pep-dortmund.org).
+
+<script defer src="assets/js/free_places.js">

--- a/_posts/2022/2022-12-12-bewerbungs_workshop.md
+++ b/_posts/2022/2022-12-12-bewerbungs_workshop.md
@@ -15,4 +15,4 @@ Der Workshop findet am Wochenende vom 13. bis zum 15. Jaunar in Essen statt und 
 
 Bei Fragen melde dich gerne per [Mail](mailto:workshop@pep-dortmund.org).
 
-<script defer src="assets/js/free_places.js">
+<script defer src="/assets/js/free_places.js">

--- a/assets/js/free_places.js
+++ b/assets/js/free_places.js
@@ -1,0 +1,12 @@
+let elements = document.getElementsByClassName("FreePlaces");
+for (let el of elements) {
+	let event = el.getAttribute("event");
+	let units = el.getAttribute("units") ?? "freie Plätze";
+	let unit = el.getAttribute("unit") ?? "freier Platz";
+	fetch("https://run.mocky.io/v3/118a49d2-2aaa-40b6-85e7-a476dcab5829")
+		.then((resp) => resp.json())
+		.then((data) => {
+			const fp = data.event.free_places;
+			el.innerHTML = el.innerHTML.replace("free_places", fp + " " + (fp > 1 ? units : unit));
+		});
+}

--- a/assets/js/free_places.js
+++ b/assets/js/free_places.js
@@ -3,10 +3,11 @@ for (let el of elements) {
 	let event = el.getAttribute("event");
 	let units = el.getAttribute("units") ?? "freie Plätze";
 	let unit = el.getAttribute("unit") ?? "freier Platz";
-	fetch("https://run.mocky.io/v3/118a49d2-2aaa-40b6-85e7-a476dcab5829")
+	fetch("https://registration.pep-dortmund.org/events/" + event + "/")
 		.then((resp) => resp.json())
 		.then((data) => {
 			const fp = data.event.free_places;
 			el.innerHTML = el.innerHTML.replace("free_places", fp + " " + (fp > 1 ? units : unit));
-		});
+		})
+		.catch(() => el.innerHTML = "");
 }


### PR DESCRIPTION
Now people can directly see in the post how many places are left for an event. 
(This took longer than expected, since CORS had to be set up in the member-database) 
### Checklist

- [x] All included images are public domain images or their respective licenses are respected (e.g. attribution for CC-BY)
- [x] Images are reduced to around 2000px at the long edge and in jpg format 
