### PR TITLE
Update ruby version in deploy CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
       - main
   schedule:
     # Every Sunday at 23:00 UTC
-    - cron: 0 23 * * 0
+    - cron: "0 23 * * 0"
 
 jobs:
   deploy:
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: build


### PR DESCRIPTION
Last deploy CI on main failed due to mismatching ruby versions:

https://github.com/pep-dortmund/homepage/actions/runs/7477703583/job/20350992523#step:3:44