### PR TITLE
change to graduiertenfeier

### DIFF
--- a/_data/gremien.yml
+++ b/_data/gremien.yml
@@ -12,8 +12,8 @@ vorstand:
         role: "Finanzreferent"
         image: "/images/vorstand/anno.jpg"
 
-  - name: "Absolventenfeier"
-    email: "absolventenfeier@pep-dortmund.org"
+  - name: "Graduiertenfeier"
+    email: "graduiertenfeier@pep-dortmund.org"
     people:
       - name: "Mira Arndt"
         image: "/images/vorstand/mira.jpg"


### PR DESCRIPTION
We decided to rename Absolventenfeier to Graduiertenfeier. Also changed mail address in Gremien.

### Checklist

- [x] All included images are public domain images or their respective licenses are respected (e.g. attribution for CC-BY)
- [x] Images are reduced to around 2000px at the long edge and in jpg format 
